### PR TITLE
Added setClasses method

### DIFF
--- a/src/Column.php
+++ b/src/Column.php
@@ -277,7 +277,7 @@ class Column
         return $this;
     }
     
-    public function setClass($class)
+    public function setClasses($class)
     {
         $this->classes = explode(" ", $class);
 

--- a/src/Column.php
+++ b/src/Column.php
@@ -276,6 +276,13 @@ class Column
 
         return $this;
     }
+    
+    public function setClass($class)
+    {
+        $this->classes = explode(" ", $class);
+
+        return $this;
+    }
 
     /**
      * @return array


### PR DESCRIPTION
Added setClass method to Column class, this will allow writing class names like in this example:

    $table = Table::create($this->order->items, [
            'name'  => ['label'=>'Name, 'class'=>'fixed-width bg-grey'],
            'price' => 'Price'
     ]);