### PR TITLE
The Blade "or" operator has been removed in favor of PHP's built-in ?? "null coalesce" operator, which has the same purpose and functionality

### DIFF
--- a/resources/views/table.blade.php
+++ b/resources/views/table.blade.php
@@ -1,4 +1,8 @@
-<table class="{{ $class ?? 'table' }}">
+@if (App::VERSION() > 5.6)
+    <table class="{{ $class ?? 'table' }}">
+@elseif (App::VERSION() <= 5.6)
+    <table class="{{ $class or 'table' }}">
+@endif
     @if(count($columns))
 	<thead>
 		<tr>
@@ -36,7 +40,11 @@
                     {!! $c->render($r) !!}
                     @else
                     {{-- Use the "rendered_foo" field, if available, else use the plain "foo" field --}}
-                        {!! $r->{'rendered_' . $c->getField()} ?? $r->{$c->getField()} !!}
+                        @if (App::VERSION() > 5.6)
+                            {!! $r->{'rendered_' . $c->getField()} ?? $r->{$c->getField()} !!}
+                        @elseif (App::VERSION() <= 5.6)
+                            {!! $r->{'rendered_' . $c->getField()} or $r->{$c->getField()} !!}
+                        @endif
                     @endif
                 </td>
             @endforeach

--- a/resources/views/table.blade.php
+++ b/resources/views/table.blade.php
@@ -1,4 +1,4 @@
-<table class="{{ $class or 'table' }}">
+<table class="{{ $class ?? 'table' }}">
     @if(count($columns))
 	<thead>
 		<tr>
@@ -36,7 +36,7 @@
                     {!! $c->render($r) !!}
                     @else
                     {{-- Use the "rendered_foo" field, if available, else use the plain "foo" field --}}
-                        {!! $r->{'rendered_' . $c->getField()} or $r->{$c->getField()} !!}
+                        {!! $r->{'rendered_' . $c->getField()} ?? $r->{$c->getField()} !!}
                     @endif
                 </td>
             @endforeach


### PR DESCRIPTION
From https://laravel.com/docs/5.7/upgrade: 

> The Blade "or" operator has been removed in favor of PHP's built-in ?? "null coalesce" operator, which has the same purpose and functionality

Using this package breaks Laravel 5.7.x.