### PR TITLE
Include support for Laravel 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ php artisan vendor:publish
 return view('users.index', ['table' => $table]);
 ```
 
-In your view, the table object can be rendered using its `render` function:
+In your view, the table object can be rendered using unescaped syntax:
 
 ```php
 {!! $table !!}

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ return view('users.index', ['table' => $table]);
 In your view, the table object can be rendered using its `render` function:
 
 ```php
-{!! $table->render() !!}
+{!! $table !!}
 ```
 
 Which would render something like this:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "laravel/framework": "5.*"
+        "laravel/framework": "5.*|6.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.*"

--- a/resources/views/table.blade.php
+++ b/resources/views/table.blade.php
@@ -1,4 +1,4 @@
-<table class="{{ $class or 'table' }}">
+<table class="{{ $class ?? 'table' }}">
     @if(count($columns))
 	<thead>
 		<tr>
@@ -36,7 +36,7 @@
                     {!! $c->render($r) !!}
                     @else
                     {{-- Use the "rendered_foo" field, if available, else use the plain "foo" field --}}
-                        {!! $r->{'rendered_' . $c->getField()} or $r->{$c->getField()} !!}
+                        {!! $r->{'rendered_' . $c->getField()} ?? $r->{$c->getField()} !!}
                     @endif
                 </td>
             @endforeach

--- a/src/BlankModel.php
+++ b/src/BlankModel.php
@@ -3,6 +3,7 @@
 namespace Gbrock\Table;
 
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Arr;
 
 class BlankModel implements Arrayable {
     private $attributes;
@@ -14,7 +15,7 @@ class BlankModel implements Arrayable {
 
     public function __get($name)
     {
-        return array_get($this->attributes, $name, null);
+        return Arr::get($this->attributes, $name);
     }
 
     public function __call($name, $arguments = [])

--- a/src/Column.php
+++ b/src/Column.php
@@ -1,7 +1,6 @@
 <?php namespace Gbrock\Table;
 
 use Illuminate\Support\Facades\Request;
-use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\URL;
 
 class Column
@@ -200,7 +199,7 @@ class Column
 
     protected function getCurrentInput()
     {
-        return Input::only([
+        return Request::only([
             config('gbrock-tables.key_field')     => Request::input(config('gbrock-tables.key_field')),
             config('gbrock-tables.key_direction') => Request::input(config('gbrock-tables.key_direction')),
         ]);

--- a/src/Table.php
+++ b/src/Table.php
@@ -1,6 +1,6 @@
 <?php namespace Gbrock\Table;
 
-use Illuminate\Support\Facades\Input;
+use Illuminate\Support\Facades\Request;
 use Gbrock\Table\Column;
 
 class Table
@@ -144,6 +144,15 @@ class Table
     }
 
     /**
+     * Return the render method.
+     * @return array
+     */
+    public function __toString()
+    {
+        return $this->render();
+    }
+
+    /**
      * Generate the data needed to render the view.
      * @return array
      */
@@ -220,7 +229,7 @@ class Table
     {
         if (class_basename($this->models) == 'LengthAwarePaginator') {
             // This set of models was paginated.  Make it append our current view variables.
-            $this->models->appends(Input::only(config('gbrock-tables.key_field'),
+            $this->models->appends(Request::only(config('gbrock-tables.key_field'),
                 config('gbrock-tables.key_direction')));
         }
     }

--- a/src/Traits/Sortable.php
+++ b/src/Traits/Sortable.php
@@ -1,6 +1,7 @@
 <?php namespace Gbrock\Table\Traits;
 
 use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Str;
 
 trait Sortable {
 
@@ -26,7 +27,7 @@ trait Sortable {
         }
 
         // The name of the custom function (which may or may not exist) which sorts this field
-        $sortFunctionName = 'sort' . studly_case($field);
+        $sortFunctionName = 'sort' . Str::studly($field);
 
         // does $field appear as a VALUE in list of known sortables?
         $isValueOfSortable = in_array($field, (array) $this->sortable);


### PR DESCRIPTION
With some simple changes, `gbrock/laravel-table` now supports Laravel 5 and 6.
Not yet tested for Laravel 7.